### PR TITLE
Update packaging: allow usage of source service

### DIFF
--- a/zypper-package-search-plugin.changes
+++ b/zypper-package-search-plugin.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr 16 13:12:16 UTC 2018 - dimstar@opensuse.org
+
+- Don't use obsolete $RPM_ shell variables.
+- Prepare for the package to be maintained by source services.
+
+-------------------------------------------------------------------
 Fri Apr 13 09:19:00 UTC 2018 - jsrain@suse.cz
 
 - Added more output options

--- a/zypper-package-search-plugin.spec
+++ b/zypper-package-search-plugin.spec
@@ -23,8 +23,7 @@ Summary:        Zypper subcommand for online package search
 License:        GPL-2.0-only
 Group:          System/Packages
 URL:            https://github.com/jsrain/zypper-package-search
-Source0:        zypper-package-search
-Source1:        COPYING
+Source0:        zypper-package-search-git.tar.xz
 BuildRequires:  ruby-macros >= 5
 BuildRequires:  zypper >= 1.11.38
 Requires:       zypper >= 1.11.38
@@ -37,14 +36,13 @@ Zypper subcommand for online package search via
 the API of the SUSE Customer Center.
 
 %prep
+%setup -q -n zypper-package-search-git
 
 %build
 
 %install
-mkdir -p $RPM_BUILD_ROOT/usr/lib/zypper/commands
-install -m 755 %{S:0} $RPM_BUILD_ROOT/usr/lib/zypper/commands/
-install -d ${RPM_BUILD_ROOT}%{_defaultlicensedir}/%{name}
-install -m 644 %{S:1} ${RPM_BUILD_ROOT}%{_defaultlicensedir}/%{name}
+mkdir -p %{buildroot}%{_prefix}/lib/zypper/commands
+install -m 755 zypper-package-search %{buildroot}%{_prefix}/lib/zypper/commands/
 
 %files
 %license COPYING


### PR DESCRIPTION
This together with an SR (currently my branch points to my git branch) will probably be what you want:

* spec and changes are maintained inside git
* whenever the package needs to be update in OBS, one just has to run ```osc service dr; osc ci -m updated``` in a checked-out obs package, and is then ready to ```osc sr -m 'submit updates'```

